### PR TITLE
Feature/handle redirect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,11 @@
       <version>5.4.2</version>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+          <version>3.4</version>
+      </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/github/digitopolis/httpserver/parser/RequestParser.java
+++ b/src/main/java/com/github/digitopolis/httpserver/parser/RequestParser.java
@@ -19,7 +19,6 @@ public class RequestParser {
         parseInitialLine(input);
         parseHeaders(input);
         if (headers.containsKey("Content-Length")) {
-            System.out.println("headers includes content length");
             parseBody(input);
         }
 
@@ -57,7 +56,6 @@ public class RequestParser {
 
     private void parseBody(BufferedReader input) throws IOException {
         if (headers.get("Content-Length").equals("0")) return;
-        System.out.println("parsing body");
         Integer contentLength = Integer.parseInt(headers.get("Content-Length"));
         StringBuilder requestBody = new StringBuilder();
         for (int i = 0; i < contentLength; i++) {

--- a/src/main/java/com/github/digitopolis/httpserver/response/HTTPResponse.java
+++ b/src/main/java/com/github/digitopolis/httpserver/response/HTTPResponse.java
@@ -3,6 +3,7 @@ package com.github.digitopolis.httpserver.response;
 import com.github.digitopolis.httpserver.HTMLBuilder;
 
 import java.util.HashMap;
+import org.apache.commons.lang3.StringUtils;
 
 public class HTTPResponse {
     public String httpVersion;
@@ -41,6 +42,17 @@ public class HTTPResponse {
 
     public String getStatusLine() {
         return String.format("%s %s %s", httpVersion, statusCode, reason);
+    }
+
+    public String getHeaders() {
+        StringBuilder headerString = new StringBuilder();
+        if (!headers.isEmpty()) {
+            headers.forEach((header, value) -> {
+                headerString.append(String.format("%s: %s\n", header, value));
+            });
+            return StringUtils.chomp(headerString.toString());
+        }
+        return "";
     }
     public String getMethod() {
         return method;

--- a/src/main/java/com/github/digitopolis/httpserver/response/ResponseFormatter.java
+++ b/src/main/java/com/github/digitopolis/httpserver/response/ResponseFormatter.java
@@ -21,7 +21,7 @@ public class ResponseFormatter {
         StringBuilder formattedGet = new StringBuilder();
         formattedGet.append(response.getStatusLine());
         formattedGet.append(CRLF);
-        formattedGet.append(response.getContentType());
+        formattedGet.append(response.getHeaders());
         formattedGet.append(CRLF);
         formattedGet.append(CRLF);
         formattedGet.append(response.getBody());

--- a/src/main/java/com/github/digitopolis/httpserver/router/Router.java
+++ b/src/main/java/com/github/digitopolis/httpserver/router/Router.java
@@ -14,6 +14,7 @@ public class Router {
         routes.put("/simple_get_with_body", new String[] { "GET", "HEAD" });
         routes.put("/head_request", new String[] { "HEAD" });
         routes.put("/echo_body", new String[] { "POST" });
+        routes.put("/redirect", new String[] { "GET" });
     }
 
     public static HTTPResponse handleRequest(HttpRequest request) {
@@ -36,6 +37,8 @@ public class Router {
                     response.addContentType(request.headers.get("Content-Type"));
                     response.addBody(request.body);
                     return response;
+                case "/redirect":
+                    return new HTTPResponse(request.httpVersion, "301", "Moved Permanently");
                 default:
                     return new HTTPResponse(request.httpVersion, "404", "Not Found");
             }

--- a/src/main/java/com/github/digitopolis/httpserver/router/Router.java
+++ b/src/main/java/com/github/digitopolis/httpserver/router/Router.java
@@ -29,7 +29,7 @@ public class Router {
                     return new HTTPResponse(request.httpVersion, "200", "OK");
                 case "/simple_get_with_body":
                     response = new HTTPResponse(request.httpVersion, "200", "OK");
-                    response.addContentType("text/html");
+                    response.addHeader("Content-Type", "text/html");
                     response.addBodyHTML("Hello world!");
                     return response;
                 case "/echo_body":
@@ -38,7 +38,9 @@ public class Router {
                     response.addBody(request.body);
                     return response;
                 case "/redirect":
-                    return new HTTPResponse(request.httpVersion, "301", "Moved Permanently");
+                    response = new HTTPResponse(request.httpVersion, "301", "Moved Permanently");
+                    response.addHeader("Location", "http://127.0.0.1/simple_get");
+                    return response;
                 default:
                     return new HTTPResponse(request.httpVersion, "404", "Not Found");
             }

--- a/src/test/java/com/github/digitopolis/httpserver/response/HTTPResponseTest.java
+++ b/src/test/java/com/github/digitopolis/httpserver/response/HTTPResponseTest.java
@@ -12,4 +12,13 @@ public class HTTPResponseTest {
         assertEquals("10", response.headers.get("Content-Length"));
         assertTrue(response.headers.containsKey("Content-Length"));
     }
+
+    @Test
+    public void testConstructsHeadersString() {
+        HTTPResponse response = new HTTPResponse("HTTP/1.1", "200", "OK");
+        response.addHeader("Content-Length", "15");
+        response.addHeader("Content-Type", "text/plain");
+        String expectedHeaders = "Content-Length: 15\nContent-Type: text/plain";
+        assertEquals(expectedHeaders, response.getHeaders());
+    }
 }

--- a/src/test/java/com/github/digitopolis/httpserver/router/RouterTest.java
+++ b/src/test/java/com/github/digitopolis/httpserver/router/RouterTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import com.github.digitopolis.httpserver.response.HTTPResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RouterTest {
     @Test
@@ -14,5 +15,12 @@ public class RouterTest {
         HttpRequest validRequest = new HttpRequest("GET","/simple_get","HTTP/1.1");
         HTTPResponse response = Router.handleRequest(validRequest);
         assertEquals("200", response.statusCode);
+    }
+
+    @Test
+    public void testResponseForRedirectHas301StatusCode() {
+        HttpRequest redirectRequest = new HttpRequest("GET", "/redirect", "HTTP/1.1");
+        HTTPResponse response = Router.handleRequest(redirectRequest);
+        assertEquals("301", response.statusCode);
     }
 }

--- a/src/test/java/com/github/digitopolis/httpserver/router/RouterTest.java
+++ b/src/test/java/com/github/digitopolis/httpserver/router/RouterTest.java
@@ -23,4 +23,11 @@ public class RouterTest {
         HTTPResponse response = Router.handleRequest(redirectRequest);
         assertEquals("301", response.statusCode);
     }
+
+    @Test
+    public void testResponseForRedirectHasLocationHeader() {
+        HttpRequest redirectRequest = new HttpRequest("GET", "/redirect", "HTTP/1.1");
+        HTTPResponse response = Router.handleRequest(redirectRequest);
+        assertTrue(response.headers.containsKey("Location"));
+    }
 }


### PR DESCRIPTION
When client makes GET request for a resource that has moved (/redirect), server should respond with status code 301 and contain a location header with the redirect URL (http://127.0.0.1/simple_get)