### PR TITLE
Feature/method not allowed

### DIFF
--- a/src/main/java/com/github/digitopolis/httpserver/router/Router.java
+++ b/src/main/java/com/github/digitopolis/httpserver/router/Router.java
@@ -6,24 +6,27 @@ import com.github.digitopolis.httpserver.response.HTTPResponse;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 
 public class Router {
     private static final HashMap<String, String[]> routes = new HashMap<>();
     static {
-        routes.put("/simple_get", new String[] { "GET", "HEAD"});
+        routes.put("/simple_get", new String[] { "GET", "HEAD" });
         routes.put("/simple_get_with_body", new String[] { "GET", "HEAD" });
-        routes.put("/head_request", new String[] { "HEAD" });
+        routes.put("/head_request", new String[] { "HEAD", "OPTIONS" });
         routes.put("/echo_body", new String[] { "POST" });
         routes.put("/redirect", new String[] { "GET" });
     }
 
     public static HTTPResponse handleRequest(HttpRequest request) {
         if (routes.containsKey(request.path)) {
+            HTTPResponse response;
             List<String> methodList = Arrays.asList(routes.get(request.path));
             if (!methodList.contains(request.method)) {
-                return new HTTPResponse(request.httpVersion, "405", "Method Not Allowed");
+                 response = new HTTPResponse(request.httpVersion, "405", "Method Not Allowed");
+                 response.addHeader("Allow", StringUtils.join(methodList, ", "));
+                 return response;
             }
-            HTTPResponse response;
             switch (request.path) {
                 case "/simple_get":
                     return new HTTPResponse(request.httpVersion, "200", "OK");

--- a/src/main/java/com/github/digitopolis/httpserver/router/Router.java
+++ b/src/main/java/com/github/digitopolis/httpserver/router/Router.java
@@ -16,6 +16,7 @@ public class Router {
         routes.put("/head_request", new String[] { "HEAD", "OPTIONS" });
         routes.put("/echo_body", new String[] { "POST" });
         routes.put("/redirect", new String[] { "GET" });
+        routes.put("/method_options", new String[] { "GET", "HEAD", "OPTIONS" });
     }
 
     public static HTTPResponse handleRequest(HttpRequest request) {
@@ -26,6 +27,12 @@ public class Router {
                  response = new HTTPResponse(request.httpVersion, "405", "Method Not Allowed");
                  response.addHeader("Allow", StringUtils.join(methodList, ", "));
                  return response;
+            }
+            if (request.method.equals("OPTIONS")) {
+                response = new HTTPResponse(request.httpVersion, "200", "OK");
+                response.addHeader("Allow", StringUtils.join(methodList, ", "));
+                response.addHeader("Content-Length", "0");
+                return response;
             }
             switch (request.path) {
                 case "/simple_get":

--- a/src/test/java/com/github/digitopolis/httpserver/router/RouterTest.java
+++ b/src/test/java/com/github/digitopolis/httpserver/router/RouterTest.java
@@ -45,4 +45,20 @@ public class RouterTest {
         assertTrue(response.headers.containsKey("Allow"));
         assertEquals("HEAD, OPTIONS", response.headers.get("Allow"));
     }
+
+    @Test
+    public void testResponseForOptionsHasAllowHeader() {
+        HttpRequest wrongMethodRequest = new HttpRequest("OPTIONS", "/method_options", "HTTP/1.1");
+        HTTPResponse response = Router.handleRequest(wrongMethodRequest);
+        assertTrue(response.headers.containsKey("Allow"));
+        assertEquals("GET, HEAD, OPTIONS", response.headers.get("Allow"));
+    }
+
+    @Test
+    public void testResponseForOptionsHasContentLengthHeader() {
+        HttpRequest wrongMethodRequest = new HttpRequest("OPTIONS", "/method_options", "HTTP/1.1");
+        HTTPResponse response = Router.handleRequest(wrongMethodRequest);
+        assertTrue(response.headers.containsKey("Content-Length"));
+        assertEquals("0", response.headers.get("Content-Length"));
+    }
 }

--- a/src/test/java/com/github/digitopolis/httpserver/router/RouterTest.java
+++ b/src/test/java/com/github/digitopolis/httpserver/router/RouterTest.java
@@ -30,4 +30,19 @@ public class RouterTest {
         HTTPResponse response = Router.handleRequest(redirectRequest);
         assertTrue(response.headers.containsKey("Location"));
     }
+
+    @Test
+    public void testResponseForWrongMethodHas405StatusCode() {
+        HttpRequest wrongMethodRequest = new HttpRequest("GET", "/head_request", "HTTP/1.1");
+        HTTPResponse response = Router.handleRequest(wrongMethodRequest);
+        assertEquals("405", response.statusCode);
+    }
+
+    @Test
+    public void testResponseForWrongMethodHasAllowedHeader() {
+        HttpRequest wrongMethodRequest = new HttpRequest("GET", "/head_request", "HTTP/1.1");
+        HTTPResponse response = Router.handleRequest(wrongMethodRequest);
+        assertTrue(response.headers.containsKey("Allow"));
+        assertEquals("HEAD, OPTIONS", response.headers.get("Allow"));
+    }
 }


### PR DESCRIPTION
Adds handling for request to a resource using a method not defined in the routes – response is sent with a 405 status code and will include an Allow header that lists the allowed methods.

In the case of a request to a valid route using the OPTIONS method, a response is sent with a 200 status code, an Allow header, and an empty body